### PR TITLE
only recbole 1.0.x versions are compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ```
 python>=3.7.0
 pytorch>=1.7.0
-recbole>=1.0.0
+recbole~=1.0.0
 ```
 
 ## Quick-Start


### PR DESCRIPTION
The code complains that `train_neg_sample_args` is not set if you use `recbole >= 1.1.x`